### PR TITLE
Add Type Locations To package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "url": "https://github.com/mongodb-js/system-ca/issues"
   },
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "exports": {
     "require": "./lib/index.js",
-    "import": "./.esm-wrapper.mjs"
+    "import": "./.esm-wrapper.mjs",
+    "types": "./lib/index.d.ts"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
When using the new TypeScript `bundler` for `moduleResolution` I found that it would ignore the type declaration files. This seemed to fix the issue for me and might be more compatible overall.